### PR TITLE
Update for Non-Teensy Boards

### DIFF
--- a/MPU9250.h
+++ b/MPU9250.h
@@ -25,8 +25,17 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SO
 #ifndef MPU9250_h
 #define MPU9250_h
 
-#include "Arduino.h"
-#include "i2c_t3.h"  // I2C library
+#include <SPI.h>
+
+#if defined(__MK20DX128__) || defined(__MK20DX256__) || defined(__MK64FX512__) || \
+	defined(__MK66FX1M0__) || defined(__MKL26Z64__)
+    #include "i2c_t3.h"  // I2C library
+	#define Teensy
+#else
+    #include "Arduino.h"
+    #include <Wire.h>
+	#define NonTeensy
+#endif
 
 #ifndef SPI_MOSI_PIN
 #define SPI_MOSI_PIN
@@ -91,11 +100,13 @@ enum mpu9250_dlpf_bandwidth
 
 class MPU9250{
     public:
-        MPU9250(uint8_t address, uint8_t bus);
-        MPU9250(uint8_t address, uint8_t bus, i2c_pins pins);
-        MPU9250(uint8_t address, uint8_t bus, i2c_pins pins, i2c_pullup pullups);
-        MPU9250(uint8_t csPin);
-        MPU9250(uint8_t csPin, spi_mosi_pin pin);
+		#if defined(Teensy)
+			MPU9250(uint8_t address, uint8_t bus, i2c_pins pins);
+			MPU9250(uint8_t address, uint8_t bus, i2c_pins pins, i2c_pullup pullups);
+			MPU9250(uint8_t csPin, spi_mosi_pin pin);
+		#endif
+		MPU9250(uint8_t csPin);
+		MPU9250(uint8_t address, uint8_t bus);
         int begin(mpu9250_accel_range accelRange, mpu9250_gyro_range gyroRange);
         int setFilt(mpu9250_dlpf_bandwidth bandwidth, uint8_t SRD);
         int enableInt(bool enable);
@@ -119,11 +130,14 @@ class MPU9250{
     private:
         uint8_t _address;
         uint8_t _bus;
-        i2c_pins _pins;
-        i2c_pullup _pullups;
+		#define wire_bus Wire
+		#if defined(Teensy)
+			i2c_pins _pins;
+			i2c_pullup _pullups;
+			spi_mosi_pin _mosiPin;
+		#endif
+		uint8_t _csPin;
         bool _userDefI2C;
-        uint8_t _csPin;
-        spi_mosi_pin _mosiPin;
         bool _useSPI;
         bool _useSPIHS;
         float _accelScale;
@@ -134,6 +148,7 @@ class MPU9250{
 
         // SPI constants
         const uint8_t SPI_READ = 0x80;
+		const uint8_t SPI_CLOCK = 8000000;
         const uint32_t SPI_LS_CLOCK = 1000000; // 1 MHz
         const uint32_t SPI_HS_CLOCK = 20000000; // 20 MHz
 
@@ -235,7 +250,7 @@ class MPU9250{
         bool writeAK8963Register(uint8_t subAddress, uint8_t data);
         void readAK8963Registers(uint8_t subAddress, uint8_t count, uint8_t* dest);
         uint8_t whoAmI();
-        uint8_t whoAmIAK8963();
+        uint8_t whoAmIAK8963();	
 };
 
 #endif


### PR DESCRIPTION
Hi Brian

I made modifications to support non-Teensy boards for I2C and SPI.  I2C had been tested with the ESP32, Arduino 101 Curie, and the Arduino Mega.  SPI has been incorporated but not tested as of yet.  I don't have a SPI 9250 yet.  Will test when I get one.

Thanks
Mike