### PR TITLE
To work with Teensy 4.x

### DIFF
--- a/src/MPU9250.cpp
+++ b/src/MPU9250.cpp
@@ -549,9 +549,11 @@ int MPU9250FIFO::readFifo() {
     }
     if (_enFifoGyro) {
       // combine into 16 bit values
-      _gxcounts = (((int16_t)_buffer[0 + _enFifoAccel*6 + _enFifoTemp*2]) << 8) | _buffer[1 + _enFifoAccel*6 + _enFifoTemp*2];
-      _gycounts = (((int16_t)_buffer[2 + _enFifoAccel*6 + _enFifoTemp*2]) << 8) | _buffer[3 + _enFifoAccel*6 + _enFifoTemp*2];
-      _gzcounts = (((int16_t)_buffer[4 + _enFifoAccel*6 + _enFifoTemp*2]) << 8) | _buffer[5 + _enFifoAccel*6 + _enFifoTemp*2];
+	  uint16_t tmp;
+	  tmp = _enFifoAccel*6 + _enFifoTemp*2;
+      _gxcounts = (((int16_t)_buffer[0 + tmp]) << 8) | _buffer[1 + tmp];
+      _gycounts = (((int16_t)_buffer[2 + tmp]) << 8) | _buffer[3 + tmp];
+      _gzcounts = (((int16_t)_buffer[4 + tmp]) << 8) | _buffer[5 + tmp];
       // transform and convert to float values
       _gxFifo[i] = ((float)(tX[0]*_gxcounts + tX[1]*_gycounts + tX[2]*_gzcounts) * _gyroScale) - _gxb;
       _gyFifo[i] = ((float)(tY[0]*_gxcounts + tY[1]*_gycounts + tY[2]*_gzcounts) * _gyroScale) - _gyb;

--- a/src/MPU9250.h
+++ b/src/MPU9250.h
@@ -79,6 +79,8 @@ class MPU9250{
     int disableDataReadyInterrupt();
     int enableWakeOnMotion(float womThresh_mg,LpAccelOdr odr);
     int readSensor();
+	int readSensorCounts(int16_t* rawValues);
+
     float getAccelX_mss();
     float getAccelY_mss();
     float getAccelZ_mss();
@@ -189,6 +191,9 @@ class MPU9250{
     const int16_t tX[3] = {0,  1,  0}; 
     const int16_t tY[3] = {1,  0,  0};
     const int16_t tZ[3] = {0,  0, -1};
+    //const int16_t tX[3] = {1,  0,  0}; 
+    //const int16_t tY[3] = {0,  1,  0};
+    //const int16_t tZ[3] = {0,  0, 1};
     // constants
     const float G = 9.807f;
     const float _d2r = 3.14159265359f/180.0f;


### PR DESCRIPTION
Brian
This PR is to fix an issue with the library working the Teensy 4.0.  If you look at the thread https://forum.pjrc.com/threads/58688-Teensy-4-0-Clock-speed-influences-delay-and-SPI you can see the whole history.

To get it working I modified writeregs and readregs to use digitalwritefast's and added 200 nanosecond delays after going low and going high.  I wrapped the changed functions in an if def for the imxrt1062.