### PR TITLE
dlpf() not valid function, correct: dlpf_bandwidth()

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ if (!status) {
 }
 ```
 
-**DlpfBandwidth dlpf()** Returns the current digital low pass filter bandwidth setting.
+**DlpfBandwidth dlpf_bandwidth()** Returns the current digital low pass filter bandwidth setting.
 
 ```C++
 DlpfBandwidth dlpf = mpu9250.dlpf();


### PR DESCRIPTION
Looking at the mpu9250.h file, I found that `mpu9250.dlpf()`, as written in Readme, is false. 
`mpu9250.dlpf_bandwidth()` is the correct function

line(92)
 `inline DlpfBandwidth dlpf_bandwidth() const {return dlpf_bandwidth_;}`